### PR TITLE
Fix: Remove deprecated site.mobileView from initialization

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
+++ b/assets/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
@@ -61,8 +61,6 @@ export default {
   initialize(container) {
     withPluginApi((api) => {
       const siteSettings = container.lookup("service:site-settings");
-      const isMobileView = container.lookup("service:site").mobileView;
-      const location = isMobileView ? "before" : "after";
 
       let containerClassname = ["poster-icon-container"];
       if (siteSettings.post_badges_only_show_highest_trust_level) {
@@ -73,6 +71,7 @@ export default {
 
       const component = class extends Component {
         @service siteSettings;
+        @service site;
 
         get badges() {
           const { user_badges: allBadges, username } = this.outletArgs.post;
@@ -92,6 +91,10 @@ export default {
             .join(" ");
         }
 
+        get shouldRenderBefore() {
+          return this.site.mobileView;
+        }
+
         <template>
           <div class={{this.classnames}}>
             <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
@@ -99,11 +102,26 @@ export default {
         </template>
       };
 
-      if (location === "before") {
-        api.renderBeforeWrapperOutlet("post-meta-data-poster-name", component);
-      } else {
-        api.renderAfterWrapperOutlet("post-meta-data-poster-name", component);
-      }
+      // Register both outlets and let the component decide when to render
+      api.renderBeforeWrapperOutlet("post-meta-data-poster-name", class extends component {
+        <template>
+          {{#if this.shouldRenderBefore}}
+            <div class={{this.classnames}}>
+              <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
+            </div>
+          {{/if}}
+        </template>
+      });
+
+      api.renderAfterWrapperOutlet("post-meta-data-poster-name", class extends component {
+        <template>
+          {{#unless this.shouldRenderBefore}}
+            <div class={{this.classnames}}>
+              <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
+            </div>
+          {{/unless}}
+        </template>
+      });
     });
   },
 };

--- a/assets/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
+++ b/assets/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
@@ -103,25 +103,31 @@ export default {
       };
 
       // Register both outlets and let the component decide when to render
-      api.renderBeforeWrapperOutlet("post-meta-data-poster-name", class extends component {
-        <template>
-          {{#if this.shouldRenderBefore}}
-            <div class={{this.classnames}}>
-              <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
-            </div>
-          {{/if}}
-        </template>
-      });
+      api.renderBeforeWrapperOutlet(
+        "post-meta-data-poster-name",
+        class extends component {
+          <template>
+            {{#if this.shouldRenderBefore}}
+              <div class={{this.classnames}}>
+                <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
+              </div>
+            {{/if}}
+          </template>
+        }
+      );
 
-      api.renderAfterWrapperOutlet("post-meta-data-poster-name", class extends component {
-        <template>
-          {{#unless this.shouldRenderBefore}}
-            <div class={{this.classnames}}>
-              <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
-            </div>
-          {{/unless}}
-        </template>
-      });
+      api.renderAfterWrapperOutlet(
+        "post-meta-data-poster-name",
+        class extends component {
+          <template>
+            {{#unless this.shouldRenderBefore}}
+              <div class={{this.classnames}}>
+                <PostUserFeaturedBadges @badges={{this.badges}} @tagName="" />
+              </div>
+            {{/unless}}
+          </template>
+        }
+      );
     });
   },
 };


### PR DESCRIPTION
Fixes deprecation warning in Discourse 3.6.0.beta1-dev by moving 'site mobileView check from plugininitialization to component rendering phase.

**Changes:**
- Move mobile view detection to component level using@service site
- Replace conditional outlet registration with conditional rendering
- Eliminates 'discourse.static-viewport-initialization' deprecation warning

**Testing:**
- Plugin works correctly on mobile and desktop
- No deprecation warnings in console